### PR TITLE
Feature updates on OG/schema.org

### DIFF
--- a/includes/Generator/Plugins/OpenGraph.php
+++ b/includes/Generator/Plugins/OpenGraph.php
@@ -162,17 +162,11 @@ class OpenGraph implements GeneratorInterface {
 			self::$htmlElementContentKey  => $this->outputPage->getHTMLTitle()
 		] ) );
 	}
-	
-	/**
-	 * Default site_name value to $wgSitename if site_name is not defined on-page
-	 *
-	 * @return void
-	 */
-	
+
 	private function addSiteName() {
 		global $wgSitename;
 
-		if ( !isset( $this->metadata['site_name']) && $wgSitename !== null ) {
+		if ( !isset( $this->metadata['site_name'] ) && $wgSitename !== null ) {
 			$this->outputPage->addHeadItem( 'og:site_name', Html::element( 'meta', [
 				self::$htmlElementPropertyKey => 'og:site_name',
 				self::$htmlElementContentKey => $wgSitename

--- a/includes/Generator/Plugins/OpenGraph.php
+++ b/includes/Generator/Plugins/OpenGraph.php
@@ -164,7 +164,7 @@ class OpenGraph implements GeneratorInterface {
 	}
 
 	private function addSiteName() {
-		global $wgSitename;
+		MediaWikiServices::getInstance()->getMainConfig()->get( 'Sitename' );
 
 		if ( !isset( $this->metadata['site_name'] ) && $wgSitename !== null ) {
 			$this->outputPage->addHeadItem( 'og:site_name', Html::element( 'meta', [

--- a/includes/Generator/Plugins/OpenGraph.php
+++ b/includes/Generator/Plugins/OpenGraph.php
@@ -126,6 +126,7 @@ class OpenGraph implements GeneratorInterface {
 	 */
 	public function addMetadata() {
 		$this->addTitleMeta();
+		$this->addSiteName();
 
 		if ( $this->outputPage->getTitle() !== null ) {
 			$url = $this->outputPage->getTitle()->getFullURL();
@@ -160,5 +161,22 @@ class OpenGraph implements GeneratorInterface {
 			self::$htmlElementPropertyKey => $this->titlePropertyName,
 			self::$htmlElementContentKey  => $this->outputPage->getHTMLTitle()
 		] ) );
+	}
+	
+	/**
+	 * Default site_name value to $wgSitename if site_name is not defined on-page
+	 *
+	 * @return void
+	 */
+	
+	private function addSiteName() {
+		global $wgSitename;
+
+		if ( !isset( $this->metadata['site_name']) && $wgSitename !== null ) {
+			$this->outputPage->addHeadItem( 'og:site_name', Html::element( 'meta', [
+				self::$htmlElementPropertyKey => 'og:site_name',
+				self::$htmlElementContentKey => $wgSitename
+			] ) );
+		}
 	}
 }

--- a/includes/Generator/Plugins/SchemaOrg.php
+++ b/includes/Generator/Plugins/SchemaOrg.php
@@ -101,8 +101,10 @@ class SchemaOrg implements GeneratorInterface {
 
 		$meta = [
 			'@context' => 'http://schema.org',
+			'type'     => $this->getTypeMetadata(),
 			'name'     => $this->outputPage->getHTMLTitle(),
 			'headline' => $this->outputPage->getHTMLTitle(),
+			'mainEntityOfPage' => $this->outputPage->getDisplayTitle(),
 		];
 
 		if ( $this->outputPage->getTitle() !== null ) {
@@ -123,6 +125,7 @@ class SchemaOrg implements GeneratorInterface {
 			}
 		}
 
+
 		$meta['image'] = $this->getImageMetadata();
 		$meta['author'] = $this->getAuthorMetadata();
 		$meta['publisher'] = $this->getAuthorMetadata();
@@ -130,12 +133,27 @@ class SchemaOrg implements GeneratorInterface {
 
 		$this->outputPage->addHeadItem( 'jsonld-metadata', sprintf( $template, json_encode( $meta ) ) );
 	}
+	
+	/**
+	* Generate proper schema.org type in order to pass validation
+	* 
+	* @return string
+	*/
+	
+	private function getTypeMetadata() {
+		$data = $this->metadata['type'];
+		if (!isset ($this->metadata['type'])) {
+			$data = "article";
+		}
+		return $data;
+	}
 
 	/**
 	 * Generate jsonld metadata from the wiki logo or supplied file name
 	 *
 	 * @return array
 	 */
+	 
 	private function getImageMetadata() {
 		$data = [
 			'@type' => 'ImageObject',
@@ -152,18 +170,8 @@ class SchemaOrg implements GeneratorInterface {
 				// Fallthrough
 			}
 		}
-
-		try {
-			$logo = MediaWikiServices::getInstance()->getMainConfig()->get( 'Logo' );
-			$logo = wfExpandUrl( $logo );
-			$data['url'] = $logo;
-		} catch ( Exception $e ) {
-			// Uh oh either there was a ConfigException or there was an error expanding the URL.
-			// We'll bail out.
-			$data = [];
-		}
-
-		return $data;
+		
+		return $image;
 	}
 
 	/**
@@ -178,10 +186,29 @@ class SchemaOrg implements GeneratorInterface {
 			// Empty tags will be ignored
 			$sitename = '';
 		}
-
+		
+		global $wgServer;
+		
+				try {
+			$logo = MediaWikiServices::getInstance()->getMainConfig()->get( 'Logo' );
+			$logo = wfExpandUrl( $logo );
+			$data['url'] = $logo;
+		} catch ( Exception $e ) {
+			// Uh oh either there was a ConfigException or there was an error expanding the URL.
+			// We'll bail out.
+			$data = [];
+		}
+		
+		$logoLine = [
+			'@type' => 'ImageObject',
+			'url' => $logo,
+			'caption' => $sitename
+		];
 		return [
 			'@type' => 'Organization',
 			'name' => $sitename,
+			'url' => $wgServer,
+			'logo' => $logoLine
 		];
 	}
 

--- a/includes/Generator/Plugins/SchemaOrg.php
+++ b/includes/Generator/Plugins/SchemaOrg.php
@@ -187,7 +187,7 @@ class SchemaOrg implements GeneratorInterface {
 			$sitename = '';
 		}
 
-		global $wgServer;
+		MediaWikiServices::getInstance()->getMainConfig()->get( 'Server' );
 
 				try {
 			$logo = MediaWikiServices::getInstance()->getMainConfig()->get( 'Logo' );

--- a/includes/Generator/Plugins/SchemaOrg.php
+++ b/includes/Generator/Plugins/SchemaOrg.php
@@ -105,6 +105,7 @@ class SchemaOrg implements GeneratorInterface {
 			'name'     => $this->outputPage->getHTMLTitle(),
 			'headline' => $this->outputPage->getHTMLTitle(),
 			'mainEntityOfPage' => $this->outputPage->getDisplayTitle(),
+			'license' => $this->getRights(),
 		];
 
 		if ( $this->outputPage->getTitle() !== null ) {
@@ -125,7 +126,6 @@ class SchemaOrg implements GeneratorInterface {
 			}
 		}
 
-
 		$meta['image'] = $this->getImageMetadata();
 		$meta['author'] = $this->getAuthorMetadata();
 		$meta['publisher'] = $this->getAuthorMetadata();
@@ -133,16 +133,16 @@ class SchemaOrg implements GeneratorInterface {
 
 		$this->outputPage->addHeadItem( 'jsonld-metadata', sprintf( $template, json_encode( $meta ) ) );
 	}
-	
+
 	/**
 	* Generate proper schema.org type in order to pass validation
-	* 
+	*
 	* @return string
 	*/
-	
+
 	private function getTypeMetadata() {
 		$data = $this->metadata['type'];
-		if (!isset ($this->metadata['type'])) {
+		if ( !isset( $this->metadata['type'] ) ) {
 			$data = "article";
 		}
 		return $data;
@@ -153,7 +153,7 @@ class SchemaOrg implements GeneratorInterface {
 	 *
 	 * @return array
 	 */
-	 
+
 	private function getImageMetadata() {
 		$data = [
 			'@type' => 'ImageObject',
@@ -170,7 +170,7 @@ class SchemaOrg implements GeneratorInterface {
 				// Fallthrough
 			}
 		}
-		
+
 		return $image;
 	}
 
@@ -186,19 +186,19 @@ class SchemaOrg implements GeneratorInterface {
 			// Empty tags will be ignored
 			$sitename = '';
 		}
-		
+
 		global $wgServer;
-		
+
 				try {
 			$logo = MediaWikiServices::getInstance()->getMainConfig()->get( 'Logo' );
 			$logo = wfExpandUrl( $logo );
 			$data['url'] = $logo;
-		} catch ( Exception $e ) {
+		  } catch ( Exception $e ) {
 			// Uh oh either there was a ConfigException or there was an error expanding the URL.
 			// We'll bail out.
 			$data = [];
-		}
-		
+		  }
+
 		$logoLine = [
 			'@type' => 'ImageObject',
 			'url' => $logo,
@@ -236,4 +236,17 @@ class SchemaOrg implements GeneratorInterface {
 
 		return [];
 	}
+
+	private function getRights() {
+		global $wgRightsPage;
+		global $wgRightsUrl;
+		if ( $wgRightsPage !== null ) {
+			$rights = $wgRightsUrlPage;
+		} elseif ( $wgRightsUrl !== null ) {
+		$rights = $wgRightsUrl;
+		} else {
+			$rights = "Unknown";
+		}
+		return $rights;
+ }
 }

--- a/includes/Generator/Plugins/SchemaOrg.php
+++ b/includes/Generator/Plugins/SchemaOrg.php
@@ -236,17 +236,4 @@ class SchemaOrg implements GeneratorInterface {
 
 		return [];
 	}
-
-	private function getRights() {
-		global $wgRightsPage;
-		global $wgRightsUrl;
-		if ( $wgRightsPage !== null ) {
-			$rights = $wgRightsUrlPage;
-		} elseif ( $wgRightsUrl !== null ) {
-		$rights = $wgRightsUrl;
-		} else {
-			$rights = "Unknown";
-		}
-		return $rights;
- }
 }

--- a/includes/Generator/Plugins/SchemaOrg.php
+++ b/includes/Generator/Plugins/SchemaOrg.php
@@ -104,8 +104,7 @@ class SchemaOrg implements GeneratorInterface {
 			'type'     => $this->getTypeMetadata(),
 			'name'     => $this->outputPage->getHTMLTitle(),
 			'headline' => $this->outputPage->getHTMLTitle(),
-			'mainEntityOfPage' => $this->outputPage->getDisplayTitle(),
-			'license' => $this->getRights(),
+			'mainEntityOfPage' => $this->outputPage->getPageTitle(),
 		];
 
 		if ( $this->outputPage->getTitle() !== null ) {
@@ -187,7 +186,7 @@ class SchemaOrg implements GeneratorInterface {
 			$sitename = '';
 		}
 
-		MediaWikiServices::getInstance()->getMainConfig()->get( 'Server' );
+		$server = MediaWikiServices::getInstance()->getMainConfig()->get( 'Server' );
 
 				try {
 			$logo = MediaWikiServices::getInstance()->getMainConfig()->get( 'Logo' );
@@ -196,7 +195,7 @@ class SchemaOrg implements GeneratorInterface {
 		  } catch ( Exception $e ) {
 			// Uh oh either there was a ConfigException or there was an error expanding the URL.
 			// We'll bail out.
-			$data = [];
+			$logo = [];
 		  }
 
 		$logoLine = [
@@ -207,7 +206,7 @@ class SchemaOrg implements GeneratorInterface {
 		return [
 			'@type' => 'Organization',
 			'name' => $sitename,
-			'url' => $wgServer,
+			'url' => $server,
 			'logo' => $logoLine
 		];
 	}


### PR DESCRIPTION
includes/Generator/Plugins/OpenGraph.php:
- Updated behavior: if no site_name variable is set, reference $wgSitename and publish value via addSitename function

includes/Generator/Plugins/SchemaOrg.php:

- Updated behavior: because schema.org requires a type to be set in order to be read correctly, use getTypeMetadata to retrieve type. If none set, use article (as current output includes article:modified_time/article:published_time)
- Updated behavior: logo for author/publisher correctly set as its own array; url value now passed as $wgServer
- Added mainEntityOfPage value to be display title