### PR TITLE
Fix for outdated auto descriptions on page save

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Usage: $wgWikiSeoNoindexPageTitles = [ 'Custom_Title', 'Main_Page' ];
 ### $wgWikiSeoEnableAutoDescription
 Set to true to try to request a description from textextracts, if no description was given, or the description key is set to 'textextracts' or 'auto'.  
 This requires Extension:TextExtracts to be loaded.  
-The description is generated when saving the page after an edit.
+The description is generated on the first page view with the feature enabled and after the page is edited.
 
 Usage: $wgWikiSeoEnableAutoDescription = true;
 

--- a/includes/Hooks/InfoAction.php
+++ b/includes/Hooks/InfoAction.php
@@ -30,7 +30,7 @@ class InfoAction implements InfoActionHook {
 
 		$properties = array_shift( $properties );
 
-		if ( !$properties || count( $properties ) === 0 ) {
+		if ( $properties === null || count( $properties ) === 0 ) {
 			return;
 		}
 

--- a/includes/Hooks/InfoAction.php
+++ b/includes/Hooks/InfoAction.php
@@ -30,7 +30,7 @@ class InfoAction implements InfoActionHook {
 
 		$properties = array_shift( $properties );
 
-		if ( count( $properties ) === 0 ) {
+		if ( !$properties || count( $properties ) === 0 ) {
 			return;
 		}
 

--- a/includes/Hooks/PageHooks.php
+++ b/includes/Hooks/PageHooks.php
@@ -22,8 +22,6 @@ declare( strict_types=1 );
 namespace MediaWiki\Extension\WikiSEO\Hooks;
 
 use CommentStoreComment;
-use ExtensionDependencyError;
-use MediaWiki\Extension\WikiSEO\ApiDescription;
 use MediaWiki\Extension\WikiSEO\WikiSEO;
 use MediaWiki\Hook\BeforePageDisplayHook;
 use MediaWiki\MediaWikiServices;
@@ -34,7 +32,6 @@ use OutputPage;
 use ParserOutput;
 use Skin;
 use Status;
-use Title;
 
 /**
  * Hooks to run relating the page
@@ -62,7 +59,6 @@ class PageHooks implements BeforePageDisplayHook, MultiContentSaveHook {
 	 * @param int $flags
 	 * @param Status $status
 	 * @return void
-	 * @throws ExtensionDependencyError
 	 */
 	public function onMultiContentSave( $renderedRevision, $user, $summary, $flags, $status ): void {
 		$output = $renderedRevision->getRevisionParserOutput();

--- a/includes/Hooks/PageHooks.php
+++ b/includes/Hooks/PageHooks.php
@@ -76,22 +76,7 @@ class PageHooks implements BeforePageDisplayHook, MultiContentSaveHook {
 			return;
 		}
 
-		$this->saveAutoDescription( $output );
-	}
-
-	/**
-	 * @param ParserOutput $output
-	 * @throws ExtensionDependencyError
-	 */
-	private function saveAutoDescription( ParserOutput $output ): void {
-		$description = $this->loadDescriptionFromApi( $output->getTitleText() );
-
-		if ( $description === null || $description === '' ) {
-			// This will only run for new pages
-			$description = trim( substr( strip_tags( $output->getText() ), 0, 160 ) );
-		}
-
-		$output->setProperty( 'description', $description );
+		$output->setProperty( 'description', '' );
 	}
 
 	/**

--- a/includes/Hooks/PageHooks.php
+++ b/includes/Hooks/PageHooks.php
@@ -76,6 +76,6 @@ class PageHooks implements BeforePageDisplayHook, MultiContentSaveHook {
 			return;
 		}
 
-		$output->setProperty( 'description', '' );
+		$output->unsetProperty( 'description' );
 	}
 }

--- a/includes/Hooks/PageHooks.php
+++ b/includes/Hooks/PageHooks.php
@@ -78,24 +78,4 @@ class PageHooks implements BeforePageDisplayHook, MultiContentSaveHook {
 
 		$output->setProperty( 'description', '' );
 	}
-
-	/**
-	 * @param string $title
-	 * @return string|null
-	 * @throws ExtensionDependencyError
-	 */
-	private function loadDescriptionFromApi( string $title ): ?string {
-		$descriptor = new ApiDescription(
-			Title::newFromText( $title ),
-			MediaWikiServices::getInstance()->getMainConfig()->get( 'WikiSeoTryCleanAutoDescription' ) === true
-		);
-
-		try {
-			return $descriptor->getDescription();
-		} catch ( ExtensionDependencyError $e ) {
-			wfLogWarning( $e->getMessage() );
-		}
-
-		return null;
-	}
 }

--- a/includes/WikiSEO.php
+++ b/includes/WikiSEO.php
@@ -154,14 +154,8 @@ class WikiSEO {
 	 */
 	public function addMetadataToPage( OutputPage $out ): void {
 		$this->modifyPageTitle( $out );
-		
+
 		$this->loadDescriptionFromApi( $out->getTitle() );
-		$key = 'description';
-		if ( $out->getProperty( $key ) === false &&
-			isset( $this->metadata['description'] ) &&
-			!empty( $this->metadata['description'] ) ) {
-			$out->setProperty( $key, $this->metadata[$key] );
-		}
 
 		MediaWikiServices::getInstance()->getHookContainer()->run(
 			'WikiSEOPreAddMetadata',

--- a/includes/WikiSEO.php
+++ b/includes/WikiSEO.php
@@ -20,6 +20,7 @@
 namespace MediaWiki\Extension\WikiSEO;
 
 use ConfigException;
+use ExtensionDependencyError;
 use MediaWiki\Extension\WikiSEO\Generator\GeneratorInterface;
 use MediaWiki\Extension\WikiSEO\Generator\MetaTag;
 use MediaWiki\MediaWikiServices;


### PR DESCRIPTION
This should function exactly as described here - https://github.com/octfx/wiki-seo/issues/16#issuecomment-802300588

This brings back some API on page view, but only if auto descriptions are enabled and there's no description set for that page. Once a description is set for a page, it will only do a new API call after the page is saved (due to the unset on page save) if there's no manual description. I think that's worth it for up-to-date descriptions.

Feedback welcome!