### PR TITLE
Only modify page title on view action

### DIFF
--- a/includes/WikiSEO.php
+++ b/includes/WikiSEO.php
@@ -156,7 +156,7 @@ class WikiSEO {
 	 * @param OutputPage $out
 	 */
 	public function addMetadataToPage( OutputPage $out ): void {
-		if ( $out->getPageTitle() === $out->getDisplayTitle() ) {
+		if ( $out->isArticle() ) {
 			$this->modifyPageTitle( $out );
 		}
 

--- a/includes/WikiSEO.php
+++ b/includes/WikiSEO.php
@@ -156,7 +156,7 @@ class WikiSEO {
 	 * @param OutputPage $out
 	 */
 	public function addMetadataToPage( OutputPage $out ): void {
-		if ( $out->isArticle() && $out->getRequest()->getRawVal( 'diff' ) === null ) {
+		if ( $out->isArticle() && !isset( $out->getRequest()->getQueryValues()['diff'] ) ) {
 			$this->modifyPageTitle( $out );
 		}
 

--- a/includes/WikiSEO.php
+++ b/includes/WikiSEO.php
@@ -156,8 +156,7 @@ class WikiSEO {
 	 * @param OutputPage $out
 	 */
 	public function addMetadataToPage( OutputPage $out ): void {
-		$request = $out->getRequest();
-		if ( $out->isArticle() && $request->getRawVal( 'diff' ) === null ) {
+		if ( $out->isArticle() && $out->getRequest()->getRawVal( 'diff' ) === null ) {
 			$this->modifyPageTitle( $out );
 		}
 

--- a/includes/WikiSEO.php
+++ b/includes/WikiSEO.php
@@ -157,7 +157,7 @@ class WikiSEO {
 	 */
 	public function addMetadataToPage( OutputPage $out ): void {
 		$request = $out->getRequest();
-		if ( $out->isArticle() && !$request->getRawVal('diff') ) {
+		if ( $out->isArticle() && $request->getRawVal('diff', null ) !== null ) {
 			$this->modifyPageTitle( $out );
 		}
 

--- a/includes/WikiSEO.php
+++ b/includes/WikiSEO.php
@@ -156,7 +156,8 @@ class WikiSEO {
 	 * @param OutputPage $out
 	 */
 	public function addMetadataToPage( OutputPage $out ): void {
-		if ( $out->isArticle() ) {
+		$request = $out->getRequest();
+		if ( $out->isArticle() && !$request->getRawVal('diff') ) {
 			$this->modifyPageTitle( $out );
 		}
 

--- a/includes/WikiSEO.php
+++ b/includes/WikiSEO.php
@@ -157,7 +157,7 @@ class WikiSEO {
 	 */
 	public function addMetadataToPage( OutputPage $out ): void {
 		$request = $out->getRequest();
-		if ( $out->isArticle() && $request->getRawVal('diff', null ) !== null ) {
+		if ( $out->isArticle() && $request->getRawVal( 'diff' ) === null ) {
 			$this->modifyPageTitle( $out );
 		}
 

--- a/includes/WikiSEO.php
+++ b/includes/WikiSEO.php
@@ -156,7 +156,9 @@ class WikiSEO {
 	 * @param OutputPage $out
 	 */
 	public function addMetadataToPage( OutputPage $out ): void {
-		$this->modifyPageTitle( $out );
+		if ( $out->getPageTitle() === $out->getDisplayTitle() ) {
+			$this->modifyPageTitle( $out );
+		}
 
 		MediaWikiServices::getInstance()->getHookContainer()->run(
 			'WikiSEOPreAddMetadata',


### PR DESCRIPTION
Makes it so when you're viewing page history, editing, etc. it uses the default page title rather than the new one. This is something that was requested by my users that I hacked in.