### PR TITLE
Use the prefixed title text as the title meta

### DIFF
--- a/includes/Generator/Plugins/OpenGraph.php
+++ b/includes/Generator/Plugins/OpenGraph.php
@@ -176,11 +176,15 @@ class OpenGraph extends AbstractBaseGenerator implements GeneratorInterface {
 	 * @return void
 	 */
 	protected function addTitleMeta(): void {
+		$title = $this->outputPage->getHTMLTitle();
+		if ( $this->outputPage->getTitle() !== null ) {
+			$title = $this->outputPage->getTitle()->getPrefixedText() ?? $title;
+		}
 		$this->outputPage->addHeadItem(
 			$this->titlePropertyName, Html::element(
 				'meta', [
 					self::$htmlElementPropertyKey => $this->titlePropertyName,
-					self::$htmlElementContentKey => $this->outputPage->getTitle()->getPrefixedText(),
+					self::$htmlElementContentKey => $title,
 				]
 			)
 		);

--- a/includes/Generator/Plugins/OpenGraph.php
+++ b/includes/Generator/Plugins/OpenGraph.php
@@ -180,7 +180,7 @@ class OpenGraph extends AbstractBaseGenerator implements GeneratorInterface {
 			$this->titlePropertyName, Html::element(
 				'meta', [
 					self::$htmlElementPropertyKey => $this->titlePropertyName,
-					self::$htmlElementContentKey => $this->outputPage->getHTMLTitle(),
+					self::$htmlElementContentKey => $this->outputPage->getTitle()->getPrefixedText(),
 				]
 			)
 		);


### PR DESCRIPTION
This title makes more sense to me and I think looks cleaner than the HTML title, which includes the site name, since that's already covered by og:site_name or the domain is shown.