### PR TITLE
Don't save empty descriptions

### DIFF
--- a/includes/DeferredDescriptionUpdate.php
+++ b/includes/DeferredDescriptionUpdate.php
@@ -75,16 +75,18 @@ class DeferredDescriptionUpdate implements DeferrableUpdate {
 			__METHOD__
 		);
 
-		$db->insert(
-			'page_props',
-			[
-				'pp_page' => $this->title->getArticleID(),
-				'pp_propname' => 'description',
-				'pp_value' => $description,
-				'pp_sortkey' => null,
-			],
-			__METHOD__
-		);
+		if ( $description !== '' ) {
+			$db->insert(
+				'page_props',
+				[
+					'pp_page' => $this->title->getArticleID(),
+					'pp_propname' => 'description',
+					'pp_value' => $description,
+					'pp_sortkey' => null,
+				],
+				__METHOD__
+			);
+		}
 	}
 
 	/**

--- a/includes/DeferredDescriptionUpdate.php
+++ b/includes/DeferredDescriptionUpdate.php
@@ -63,30 +63,23 @@ class DeferredDescriptionUpdate implements DeferrableUpdate {
 			return;
 		}
 
+		if ( $description === '' ) {
+			return;
+		}
+
 		$dbl = MediaWikiServices::getInstance()->getDBLoadBalancer();
 		$db = $dbl->getConnection( $dbl->getWriterIndex() );
 
-		$db->delete(
+		$db->insert(
 			'page_props',
 			[
 				'pp_page' => $this->title->getArticleID(),
 				'pp_propname' => 'description',
+				'pp_value' => $description,
+				'pp_sortkey' => null,
 			],
 			__METHOD__
 		);
-
-		if ( $description !== '' ) {
-			$db->insert(
-				'page_props',
-				[
-					'pp_page' => $this->title->getArticleID(),
-					'pp_propname' => 'description',
-					'pp_value' => $description,
-					'pp_sortkey' => null,
-				],
-				__METHOD__
-			);
-		}
 	}
 
 	/**


### PR DESCRIPTION
Prevent completely empty descriptions from being saved to the database.

Before this it would generate an empty description page prop and show a blank description on page info (common for File pages or if the page has no intro). A blank meta description isn't even added to the HTML, so it has no use.