### PR TITLE
Fix for non-mainspace pages

### DIFF
--- a/includes/ApiDescription.php
+++ b/includes/ApiDescription.php
@@ -94,7 +94,7 @@ class ApiDescription {
 			'format' => 'json',
 			'action' => 'query',
 			'prop' => 'extracts',
-			'titles' => $this->title->getDBkey(),
+			'titles' => $this->title->getPrefixedText(),
 			'exchars' => 160,
 			'exintro' => 1,
 			'explaintext' => 1,


### PR DESCRIPTION
Looking through existing MediaWiki code I saw more instances of `getPrefixedText()` than `getPrefixedDBkey()` for API queries but both work if you prefer the latter