### PR TITLE
Safer checks on image parameter

### DIFF
--- a/includes/Hooks/InfoAction.php
+++ b/includes/Hooks/InfoAction.php
@@ -117,7 +117,7 @@ class InfoAction implements InfoActionHook {
 	private function formatImage( $value ): string {
 		$title = Title::newFromText( $value, NS_FILE );
 
-		if ( $title->exists() === false ) {
+		if ( $title->exists() === false || $title->inNamespace( NS_FILE ) === false ) {
 			return $value;
 		}
 

--- a/includes/Hooks/InfoAction.php
+++ b/includes/Hooks/InfoAction.php
@@ -115,9 +115,9 @@ class InfoAction implements InfoActionHook {
 	 * @return string
 	 */
 	private function formatImage( $value ): string {
-		$title = Title::newFromText( $value );
+		$title = Title::newFromText( $value, NS_FILE );
 
-		if ( $title === null ) {
+		if ( $title->exists() === false ) {
 			return $value;
 		}
 

--- a/includes/Hooks/InfoAction.php
+++ b/includes/Hooks/InfoAction.php
@@ -117,7 +117,7 @@ class InfoAction implements InfoActionHook {
 	private function formatImage( $value ): string {
 		$title = Title::newFromText( $value, NS_FILE );
 
-		if ( $title->exists() === false || $title->inNamespace( NS_FILE ) === false ) {
+		if ( $title === null || $title->exists() === false || $title->inNamespace( NS_FILE ) === false ) {
 			return $value;
 		}
 


### PR DESCRIPTION
If you had provided a full URL for the image tag, or a non-File-namespace page title, it would give this error on page info:

Error from line 127 of InfoAction.php: Call to a member function transform() on bool